### PR TITLE
New option --log-file in connectors

### DIFF
--- a/perl/build/CMakeLists.txt
+++ b/perl/build/CMakeLists.txt
@@ -256,6 +256,12 @@ if (WITH_TESTING)
     "${TEST_DIR}/connector/execute_single_script.cc")
   target_link_libraries("${TEST_NAME}" ${TEST_LIBRARIES})
   add_test("${TEST_NAME}" "${TEST_NAME}")
+  # Single script execution with log file.
+  set(TEST_NAME "connector_execute_single_script_log_file")
+  add_executable("${TEST_NAME}"
+    "${TEST_DIR}/connector/execute_single_script_log_file.cc")
+  target_link_libraries("${TEST_NAME}" ${TEST_LIBRARIES})
+  add_test("${TEST_NAME}" "${TEST_NAME}")
   # Multiple script execution.
   set(TEST_NAME "connector_execute_multiple_scripts")
   add_executable("${TEST_NAME}"

--- a/perl/src/main.cc
+++ b/perl/src/main.cc
@@ -68,7 +68,7 @@ int main(int argc, char** argv, char** env) {
   int retval(EXIT_FAILURE);
 
   // Log object.
-  logging::file log_file(stderr);
+  logging::file* log_file = NULL;
 
   try {
     // Initializations.
@@ -99,21 +99,29 @@ int main(int argc, char** argv, char** env) {
     }
     else {
       // Set logging object.
+      if (opts.get_argument("log-file").get_is_set()) {
+        std::string filename(
+            opts.get_argument("log-file").get_value());
+        log_file = new logging::file(filename);
+      }
+      else
+        log_file = new logging::file(stderr);
+
       if (opts.get_argument("debug").get_is_set()) {
-        log_file.show_pid(true);
-        log_file.show_thread_id(true);
+        log_file->show_pid(true);
+        log_file->show_thread_id(true);
         logging::engine::instance().add(
-          &log_file,
+          log_file,
           logging::type_debug
           | logging::type_info
           | logging::type_error,
           logging::high);
       }
       else {
-        log_file.show_pid(false);
-        log_file.show_thread_id(false);
+        log_file->show_pid(false);
+        log_file->show_thread_id(false);
         logging::engine::instance().add(
-          &log_file,
+          log_file,
           logging::type_info | logging::type_error,
           logging::low);
       }
@@ -148,6 +156,8 @@ int main(int argc, char** argv, char** env) {
   multiplexer::unload();
   pipe_handle::unload();
   clib::unload();
+  if (log_file)
+    delete log_file;
 
   return (retval);
 }

--- a/perl/src/options.cc
+++ b/perl/src/options.cc
@@ -30,6 +30,8 @@ static char const* const help_description
   = "Print help and exit.";
 static char const* const version_description
   = "Print software version and exit.";
+static char const* const log_file_description
+  = "Specifies the log file (default: stderr).";
 
 /**************************************
 *                                     *
@@ -152,6 +154,15 @@ void options::_init() {
     arg.set_name('v');
     arg.set_long_name("version");
     arg.set_description(version_description);
+  }
+
+  // Log file.
+  {
+    misc::argument& arg(_arguments['L']);
+    arg.set_name('L');
+    arg.set_long_name("log-file");
+    arg.set_description(log_file_description);
+    arg.set_has_value(true);
   }
 
   return ;

--- a/perl/src/options.cc
+++ b/perl/src/options.cc
@@ -158,8 +158,8 @@ void options::_init() {
 
   // Log file.
   {
-    misc::argument& arg(_arguments['L']);
-    arg.set_name('L');
+    misc::argument& arg(_arguments['l']);
+    arg.set_name('l');
     arg.set_long_name("log-file");
     arg.set_description(log_file_description);
     arg.set_has_value(true);

--- a/perl/test/connector/execute_single_script.cc
+++ b/perl/test/connector/execute_single_script.cc
@@ -18,18 +18,15 @@
 
 #include <cstdio>
 #include <cstring>
-#include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include "com/centreon/clib.hh"
-#include "com/centreon/exceptions/basic.hh"
 #include "com/centreon/io/file_stream.hh"
 #include "com/centreon/process.hh"
+#include "com/centreon/exceptions/basic.hh"
 #include "test/connector/misc.hh"
 #include "test/connector/paths.hh"
-
-#define LOG_FILE "/tmp/toto"
 
 using namespace com::centreon;
 
@@ -51,13 +48,6 @@ using namespace com::centreon;
  *  @return 0 on success.
  */
 int main() {
-  // If the log file exists, we remove it.
-  std::ifstream f(LOG_FILE);
-  if (f.good()) {
-    f.close();
-    remove(LOG_FILE);
-  }
-
   clib::load();
   // Write Perl script.
   std::string script_path(io::file_stream::temp_path());
@@ -72,7 +62,7 @@ int main() {
   process p;
   p.enable_stream(process::in, true);
   p.enable_stream(process::out, true);
-  p.exec(CONNECTOR_PERL_BINARY " --log-file " LOG_FILE);
+  p.exec(CONNECTOR_PERL_BINARY);
 
   // Write command.
   std::ostringstream oss;
@@ -121,20 +111,6 @@ int main() {
       throw (basic_error()
              << "invalid output: size=" << output.size()
              << ", output=" << replace_null(output));
-
-    std::string line;
-    std::ifstream file(LOG_FILE);
-    if (file.is_open()) {
-      getline(file, line);
-      if (line.find("[info] Centreon Perl Connector 1.1.2 starting") == std::string::npos)
-        throw (basic_error()
-               << "bad content: the first line does not start with 'Centreon SSH Connector 1.1.2 starting'");
-      file.close();
-    }
-    else {
-      throw (basic_error()
-             << "the file " LOG_FILE " has not been created.");
-    }
   }
   catch (std::exception const& e) {
     retval = 1;

--- a/perl/test/connector/execute_single_script_log_file.cc
+++ b/perl/test/connector/execute_single_script_log_file.cc
@@ -126,9 +126,9 @@ int main() {
     std::ifstream file(LOG_FILE);
     if (file.is_open()) {
       getline(file, line);
-      if (line.find("[info] Centreon Perl Connector 1.1.2 starting") == std::string::npos)
+      if (line.find("[info] Centreon Perl Connector " CENTREON_CONNECTOR_PERL_VERSION " starting") == std::string::npos)
         throw (basic_error()
-               << "bad content: the first line does not start with 'Centreon SSH Connector 1.1.2 starting'");
+               << "bad content: the first line does not start with 'Centreon Perl Connector " CENTREON_CONNECTOR_PERL_VERSION " starting'");
       file.close();
     }
     else {

--- a/perl/test/connector/execute_single_script_log_file.cc
+++ b/perl/test/connector/execute_single_script_log_file.cc
@@ -16,7 +16,6 @@
 ** For more information : contact@centreon.com
 */
 
-#include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -43,10 +42,11 @@ using namespace com::centreon;
                "1\0" \
                "0\0" \
                " \0" \
-               "Merethis is wonderful\n\0\0\0\0"
+               "Centreon is wonderful\n\0\0\0\0"
 
 /**
- *  Check that connector can execute a script.
+ *  Check that connector can execute a script with a log file.
+ *  The goal is first to verify the log file is well written.
  *
  *  @return 0 on success.
  */
@@ -65,7 +65,7 @@ int main() {
     script_path.c_str(),
     "#!/usr/bin/perl\n" \
     "\n" \
-    "print \"Merethis is wonderful\\n\";\n" \
+    "print \"Centreon is wonderful\\n\";\n" \
     "exit 0;\n");
 
   // Process.
@@ -141,5 +141,5 @@ int main() {
     std::cerr << "error: " << e.what() << std::endl;
   }
 
-  return (retval);
+  return retval;
 }

--- a/ssh/build/CMakeLists.txt
+++ b/ssh/build/CMakeLists.txt
@@ -593,6 +593,12 @@ if (WITH_TESTING)
     "${TEST_DIR}/connector/command_execute.cc")
   target_link_libraries("${TEST_NAME}" ${TEST_LIBRARIES})
   add_test("${TEST_NAME}" "${TEST_NAME}")
+  # Execute command with a log file
+  set(TEST_NAME "connector_command_execute_log_file")
+  add_executable("${TEST_NAME}"
+    "${TEST_DIR}/connector/command_execute_log_file.cc")
+  target_link_libraries("${TEST_NAME}" ${TEST_LIBRARIES})
+  add_test("${TEST_NAME}" "${TEST_NAME}")
   # Non-existent host.
   set(TEST_NAME "connector_non_existent_host")
   add_executable("${TEST_NAME}"

--- a/ssh/src/options.cc
+++ b/ssh/src/options.cc
@@ -29,6 +29,8 @@ static char const* const help_description
   = "Print help and exit.";
 static char const* const version_description
   = "Print software version and exit.";
+static char const* const log_file_description
+  = "Specifies the log file (default: stderr).";
 
 /**************************************
 *                                     *
@@ -79,6 +81,7 @@ std::string options::help() const {
       << "  --debug    " << debug_description << "\n"
       << "  --help     " << help_description << "\n"
       << "  --version  " << version_description << "\n"
+      << "  --log-file " << log_file_description << "\n"
       << "\n"
       << "Commands must be sent on the connector's standard input.\n"
       << "They must be sent using Centreon Connector protocol version\n"
@@ -141,6 +144,15 @@ void options::_init() {
     arg.set_name('v');
     arg.set_long_name("version");
     arg.set_description(version_description);
+  }
+
+  // Log file.
+  {
+    misc::argument& arg(_arguments['L']);
+    arg.set_name('L');
+    arg.set_long_name("log-file");
+    arg.set_description(log_file_description);
+    arg.set_has_value(true);
   }
 
   return ;

--- a/ssh/src/options.cc
+++ b/ssh/src/options.cc
@@ -148,8 +148,8 @@ void options::_init() {
 
   // Log file.
   {
-    misc::argument& arg(_arguments['L']);
-    arg.set_name('L');
+    misc::argument& arg(_arguments['l']);
+    arg.set_name('l');
     arg.set_long_name("log-file");
     arg.set_description(log_file_description);
     arg.set_has_value(true);

--- a/ssh/src/policy.cc
+++ b/ssh/src/policy.cc
@@ -263,8 +263,10 @@ void policy::on_result(checks::result const& r) {
              end = _checks.end();
            it != end;
            ++it)
-        if (it->second.second == sess)
+        if (it->second.second == sess) {
           found = true;
+          break;
+        }
       if (!found) {
         std::map<sessions::credentials, sessions::session*>::iterator
           it, end;

--- a/ssh/src/sessions/session.cc
+++ b/ssh/src/sessions/session.cc
@@ -591,9 +591,16 @@ void session::_startup() {
   libssh2_session_set_blocking(_session, 0);
 
   // Exchange banners, keys, setup crypto, compression, ...
+#if LIBSSH2_VERSION_NUM >= 0x010208
+  // libssh2_session_startup deprecated in version 1.2.8 and later
+  int retval(libssh2_session_handshake(
+                _session,
+                _socket.get_native_handle()));
+#else
   int retval(libssh2_session_startup(
                _session,
                _socket.get_native_handle()));
+#endif
   if (retval) {
     if (retval != LIBSSH2_ERROR_EAGAIN) { // Fatal failure.
       char* msg;

--- a/ssh/test/connector/command_execute_log_file.cc
+++ b/ssh/test/connector/command_execute_log_file.cc
@@ -1,0 +1,143 @@
+/*
+** Copyright 2012-2013 Centreon
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+**
+** For more information : contact@centreon.com
+*/
+
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <string>
+#include "com/centreon/clib.hh"
+#include "com/centreon/exceptions/basic.hh"
+#include "com/centreon/process.hh"
+#include "test/connector/binary.hh"
+
+#define LOG_FILE "/tmp/toto"
+
+using namespace com::centreon;
+
+#define CMD1 "2\0" \
+             "4242\0" \
+             "5\0" \
+             "123456789\0" \
+             "check_by_ssh " \
+             "-H localhost " \
+             " -C 'echo Bonjour'\0\0\0\0"
+#define RESULT "3\0" \
+               "4242\0" \
+               "1\0" \
+               "0\0" \
+               " \0" \
+               "Bonjour\n\0\0\0\0"
+
+/**
+ *  Replace null char by string "\0".
+ *
+ *  @param[in, out] str  The string to replace.
+ *
+ *  @return The replace string.
+ */
+std::string& replace_null(std::string& str) {
+  size_t pos(0);
+  while ((pos = str.find('\0', pos)) != std::string::npos)
+    str.replace(pos++, 1, "\\0");
+  return (str);
+}
+
+/**
+ *  Check that connector respond properly to version command.
+ *
+ *  @return 0 on success.
+ */
+int main() {
+  std::ifstream f(LOG_FILE);
+  if (f.good()) {
+    f.close();
+    remove(LOG_FILE);
+  }
+
+  clib::load();
+  // Process.
+  process p;
+  p.enable_stream(process::in, true);
+  p.enable_stream(process::out, true);
+  p.exec(CONNECTOR_SSH_BINARY " --log-file " LOG_FILE);
+
+  // Write command.
+  std::ostringstream oss;
+  oss.write(CMD1, sizeof(CMD1) - 1);
+  std::string cmd(oss.str());
+  char const* ptr(cmd.c_str());
+  unsigned int size(cmd.size());
+  while (size > 0) {
+    unsigned int rb(p.write(ptr, size));
+    size -= rb;
+    ptr += rb;
+  }
+  p.enable_stream(process::in, false);
+
+  // Read reply.
+  std::string output;
+  while (true) {
+    std::string buffer;
+    p.read(buffer);
+    if (buffer.empty())
+      break;
+    output.append(buffer);
+  }
+
+  // Wait for process termination.
+  int retval(1);
+  if (!p.wait(5000)) {
+    p.terminate();
+    p.wait();
+  }
+  else
+    retval = (p.exit_code() != 0);
+
+  clib::unload();
+
+  try {
+    if (retval)
+      throw (basic_error() << "invalid return code: " << retval);
+    if (output.size() != (sizeof(RESULT) - 1)
+        || memcmp(output.c_str(), RESULT, sizeof(RESULT) - 1))
+      throw (basic_error()
+             << "invalid output: size=" << output.size()
+             << ", output=" << replace_null(output));
+
+    std::string line;
+    std::ifstream file(LOG_FILE);
+    if (file.is_open()) {
+      getline(file, line);
+      if (line.find("[info] Centreon SSH Connector 1.1.2 starting") == std::string::npos)
+        throw (basic_error()
+               << "bad content: the first line does not start with 'Centreon SSH Connector 1.1.2 starting'");
+      file.close();
+    }
+    else {
+      throw (basic_error()
+             << "the file " LOG_FILE " has not been created.");
+    }
+  }
+  catch (std::exception const& e) {
+    retval = 1;
+    std::cerr << "error: " << e.what() << std::endl;
+  }
+
+  return retval;
+}

--- a/ssh/test/connector/command_execute_log_file.cc
+++ b/ssh/test/connector/command_execute_log_file.cc
@@ -124,9 +124,9 @@ int main() {
     std::ifstream file(LOG_FILE);
     if (file.is_open()) {
       getline(file, line);
-      if (line.find("[info] Centreon SSH Connector 1.1.2 starting") == std::string::npos)
+      if (line.find("[info] Centreon SSH Connector " CENTREON_CONNECTOR_SSH_VERSION " starting") == std::string::npos)
         throw (basic_error()
-               << "bad content: the first line does not start with 'Centreon SSH Connector 1.1.2 starting'");
+               << "bad content: the first line does not start with 'Centreon SSH Connector " CENTREON_CONNECTOR_SSH_VERSION " starting'");
       file.close();
     }
     else {


### PR DESCRIPTION
We can launch any of the connectors with the option _--log-file /tmp/titi_ to specify a log file /tmp/titi.

This is useful to debug a connector.
