### PR TITLE
fix(timeout): timeout is a timestamp, more accurate than time_t

### DIFF
--- a/perl/doc/release_notes/centreon_connector_perl_20_04.rst
+++ b/perl/doc/release_notes/centreon_connector_perl_20_04.rst
@@ -1,0 +1,14 @@
+===============================
+Centreon Perl Connector 20.04.0
+===============================
+
+*********
+Bug fixes
+*********
+
+wrong check timeout
+===================
+
+The timeout given by Engine to the connector was decremented by 1. Moreover it
+was not sufficiently accurate, so the timeout was reached too soon. Now it is
+considered as milliseconds with the good value.

--- a/perl/inc/com/centreon/connector/perl/checks/check.hh
+++ b/perl/inc/com/centreon/connector/perl/checks/check.hh
@@ -24,6 +24,7 @@
 #include "com/centreon/connector/perl/namespace.hh"
 #include "com/centreon/connector/perl/pipe_handle.hh"
 #include "com/centreon/handle_listener.hh"
+#include "com/centreon/timestamp.hh"
 
 CCCP_BEGIN()
 
@@ -43,7 +44,9 @@ class check : public handle_listener {
   check();
   ~check() throw();
   void error(handle& h);
-  pid_t execute(unsigned long long cmd_id, std::string const& cmd, time_t tmt);
+  pid_t execute(unsigned long long cmd_id,
+                std::string const& cmd,
+                const timestamp& tmt);
   void listen(listener* listnr);
   void on_timeout(bool final = true);
   void read(handle& h);

--- a/perl/inc/com/centreon/connector/perl/orders/listener.hh
+++ b/perl/inc/com/centreon/connector/perl/orders/listener.hh
@@ -22,6 +22,7 @@
 #include <ctime>
 #include <string>
 #include "com/centreon/connector/perl/namespace.hh"
+#include "com/centreon/timestamp.hh"
 
 CCCP_BEGIN()
 
@@ -42,7 +43,7 @@ class listener {
   virtual void on_eof() = 0;
   virtual void on_error() = 0;
   virtual void on_execute(unsigned long long cmd_id,
-                          time_t timeout,
+                          const timestamp& timeout,
                           std::string const& cmd) = 0;
   virtual void on_quit() = 0;
   virtual void on_version() = 0;

--- a/perl/inc/com/centreon/connector/perl/policy.hh
+++ b/perl/inc/com/centreon/connector/perl/policy.hh
@@ -27,6 +27,7 @@
 #include "com/centreon/connector/perl/orders/parser.hh"
 #include "com/centreon/connector/perl/reporter.hh"
 #include "com/centreon/io/file_stream.hh"
+#include "com/centreon/timestamp.hh"
 
 CCCP_BEGIN()
 
@@ -59,7 +60,7 @@ class policy : public orders::listener, public checks::listener {
   void on_eof();
   void on_error();
   void on_execute(unsigned long long cmd_id,
-                  time_t timeout,
+                  const timestamp& timeout,
                   std::string const& cmd);
   void on_quit();
   void on_result(checks::result const& r);

--- a/perl/src/checks/check.cc
+++ b/perl/src/checks/check.cc
@@ -77,7 +77,7 @@ void check::error(handle& h) {
  */
 pid_t check::execute(unsigned long long cmd_id,
                      std::string const& cmd,
-                     time_t tmt) {
+                     const timestamp& tmt) {
   // Run process.
   int fds[3];
   _child = embedded_perl::instance().run(cmd, fds);
@@ -96,10 +96,10 @@ pid_t check::execute(unsigned long long cmd_id,
   // Register timeout.
   std::unique_ptr<timeout> t(new timeout(this, false));
   _timeout = multiplexer::instance().com::centreon::task_manager::add(
-      t.get(), tmt - 1, false, true);
+      t.get(), tmt, false, true);
   t.release();
 
-  return (_child);
+  return _child;
 }
 
 /**
@@ -222,7 +222,7 @@ void check::unlisten(listener* listnr) {
  */
 bool check::want_read(handle& h) {
   (void)h;
-  return (true);
+  return true;
 }
 
 /**

--- a/perl/src/orders/parser.cc
+++ b/perl/src/orders/parser.cc
@@ -22,6 +22,7 @@
 #include <string>
 #include "com/centreon/exceptions/basic.hh"
 #include "com/centreon/logging/logger.hh"
+#include "com/centreon/timestamp.hh"
 
 using namespace com::centreon::connector::perl::orders;
 
@@ -191,13 +192,15 @@ void parser::_parse(std::string const& cmd) {
       pos = end + 1;
       // Find timeout value.
       end = cmd.find('\0', pos);
-      time_t timeout(
-          static_cast<time_t>(strtoull(cmd.c_str() + pos, &ptr, 10)));
+      time_t timeout =
+          static_cast<time_t>(strtoull(cmd.c_str() + pos, &ptr, 10));
+      timestamp ts_timeout = timestamp::now();
+
       if (*ptr)
         throw(basic_error() << "invalid execution request received:"
                                " bad timeout ("
                             << cmd.c_str() + pos << ")");
-      timeout += time(NULL);
+      ts_timeout += timeout;
       pos = end + 1;
       // Find start time.
       end = cmd.find('\0', pos);
@@ -213,7 +216,7 @@ void parser::_parse(std::string const& cmd) {
 
       // Notify listener.
       if (_listnr)
-        _listnr->on_execute(cmd_id, timeout, cmdline);
+        _listnr->on_execute(cmd_id, ts_timeout, cmdline);
     } break;
     case 4:  // Quit query.
       if (_listnr)

--- a/perl/src/policy.cc
+++ b/perl/src/policy.cc
@@ -103,7 +103,7 @@ void policy::on_error() {
  *  @param[in] cmd     Command to execute.
  */
 void policy::on_execute(unsigned long long cmd_id,
-                        time_t timeout,
+                        const timestamp& timeout,
                         std::string const& cmd) {
   std::unique_ptr<checks::check> chk(new checks::check);
   chk->listen(this);

--- a/ssh/doc/release_notes/centreon_connector_ssh_20_04.rst
+++ b/ssh/doc/release_notes/centreon_connector_ssh_20_04.rst
@@ -1,0 +1,14 @@
+===============================
+Centreon Perl Connector 20.04.0
+===============================
+
+*********
+Bug fixes
+*********
+
+wrong check timeout
+===================
+
+The timeout given by Engine to the connector was decremented by 1. Moreover it
+was not sufficiently accurate, so the timeout was reached too soon. Now it is
+considered as milliseconds with the good value.

--- a/ssh/inc/com/centreon/connector/ssh/checks/check.hh
+++ b/ssh/inc/com/centreon/connector/ssh/checks/check.hh
@@ -26,6 +26,7 @@
 #include "com/centreon/connector/ssh/namespace.hh"
 #include "com/centreon/connector/ssh/sessions/listener.hh"
 #include "com/centreon/connector/ssh/sessions/session.hh"
+#include "com/centreon/timestamp.hh"
 
 CCCS_BEGIN()
 
@@ -46,7 +47,7 @@ class check : public sessions::listener {
   void execute(sessions::session& sess,
                unsigned long long cmd_id,
                std::list<std::string> const& cmds,
-               time_t tmt);
+               const timestamp& tmt);
   void listen(checks::listener* listnr);
   void on_available(sessions::session& sess);
   void on_close(sessions::session& sess);

--- a/ssh/inc/com/centreon/connector/ssh/orders/listener.hh
+++ b/ssh/inc/com/centreon/connector/ssh/orders/listener.hh
@@ -23,6 +23,7 @@
 #include <list>
 #include <string>
 #include "com/centreon/connector/ssh/namespace.hh"
+#include "com/centreon/timestamp.hh"
 
 CCCS_BEGIN()
 
@@ -43,7 +44,7 @@ class listener {
   virtual void on_eof() = 0;
   virtual void on_error(uint64_t cmd_id, char const* msg) = 0;
   virtual void on_execute(uint64_t cmd_id,
-                          time_t timeout,
+                          const timestamp& timeout,
                           std::string const& host,
                           unsigned short port,
                           std::string const& user,

--- a/ssh/inc/com/centreon/connector/ssh/policy.hh
+++ b/ssh/inc/com/centreon/connector/ssh/policy.hh
@@ -28,6 +28,7 @@
 #include "com/centreon/connector/ssh/reporter.hh"
 #include "com/centreon/connector/ssh/sessions/credentials.hh"
 #include "com/centreon/io/file_stream.hh"
+#include "com/centreon/timestamp.hh"
 
 CCCS_BEGIN()
 
@@ -53,7 +54,7 @@ class policy : public orders::listener, public checks::listener {
   void on_eof();
   void on_error(uint64_t cmd_id, char const* msg);
   void on_execute(uint64_t cmd_id,
-                  time_t timeout,
+                  const timestamp& timeout,
                   std::string const& host,
                   unsigned short port,
                   std::string const& user,

--- a/ssh/src/checks/check.cc
+++ b/ssh/src/checks/check.cc
@@ -92,7 +92,7 @@ check::~check() throw() {
 void check::execute(sessions::session& sess,
                     unsigned long long cmd_id,
                     std::list<std::string> const& cmds,
-                    time_t tmt) {
+                    const timestamp& tmt) {
   // Log message.
   log_debug(logging::low) << "check " << this << " has ID " << cmd_id;
 

--- a/ssh/src/orders/parser.cc
+++ b/ssh/src/orders/parser.cc
@@ -192,11 +192,13 @@ void parser::_parse(std::string const& cmd) {
       end = cmd.find('\0', pos);
       time_t timeout(
           static_cast<time_t>(strtoull(cmd.c_str() + pos, &ptr, 10)));
+      timestamp ts_timeout = timestamp::now();
+
       if (*ptr)
         throw(basic_error() << "invalid execution request received:"
                                " bad timeout ("
                             << cmd.c_str() + pos << ")");
-      timeout += time(NULL);
+      ts_timeout += timeout;
       pos = end + 1;
       // Find start time.
       end = cmd.find('\0', pos);
@@ -224,7 +226,7 @@ void parser::_parse(std::string const& cmd) {
 
         if (opt.get_timeout() &&
             opt.get_timeout() < static_cast<unsigned int>(timeout))
-          timeout = time(NULL) + opt.get_timeout();
+          ts_timeout = timestamp::now() + opt.get_timeout();
         else if (opt.get_timeout() > static_cast<unsigned int>(timeout))
           throw(basic_error()
                 << "invalid execution request "
@@ -237,7 +239,7 @@ void parser::_parse(std::string const& cmd) {
 
       // Notify listener.
       if (_listnr)
-        _listnr->on_execute(cmd_id, timeout, opt.get_host(), opt.get_port(),
+        _listnr->on_execute(cmd_id, ts_timeout, opt.get_host(), opt.get_port(),
                             opt.get_user(), opt.get_authentication(),
                             opt.get_identity_file(), opt.get_commands(),
                             opt.skip_stdout(), opt.skip_stderr(),

--- a/ssh/src/policy.cc
+++ b/ssh/src/policy.cc
@@ -132,7 +132,7 @@ void policy::on_error(uint64_t cmd_id, char const* msg) {
  *  @param[in] use_ipv6    Version of ip protocol to use.
  */
 void policy::on_execute(uint64_t cmd_id,
-                        time_t timeout,
+                        const timestamp& timeout,
                         std::string const& host,
                         unsigned short port,
                         std::string const& user,
@@ -144,10 +144,10 @@ void policy::on_execute(uint64_t cmd_id,
                         bool use_ipv6) {
   try {
     // Log message.
-    log_info(logging::medium)
-        << "got request to execute check " << cmd_id << " on session " << user
-        << "@" << host << " (timeout " << timeout << ", first command \""
-        << cmds.front() << "\")";
+    log_info(logging::medium) << "got request to execute check " << cmd_id
+                              << " on session " << user << "@" << host
+                              << " (timeout " << timeout.to_seconds()
+                              << ", first command \"" << cmds.front() << "\")";
 
     // Credentials.
     sessions::credentials creds;

--- a/ssh/test/orders/fake_listener.cc
+++ b/ssh/test/orders/fake_listener.cc
@@ -28,47 +28,13 @@ using namespace com::centreon::connector::ssh::orders;
 **************************************/
 
 /**
- *  Default constructor.
- */
-//fake_listener::fake_listener() {}
-
-/**
- *  Copy constructor.
- *
- *  @param[in] fl Object to copy.
- */
-//fake_listener::fake_listener(fake_listener const& fl) : listener(fl) {
-//  _copy(fl);
-//}
-
-/**
- *  Destructor.
- */
-//fake_listener::~fake_listener() {}
-
-/**
- *  Assignment operator.
- *
- *  @param[in] fl Object to copy.
- *
- *  @return This object.
- */
-//fake_listener& fake_listener::operator=(fake_listener const& fl) {
-//  if (this != &fl) {
-//    listener::operator=(fl);
-//    _copy(fl);
-//  }
-//  return (*this);
-//}
-
-/**
  *  Get the callbacks information.
  *
  *  @return Callbacks information.
  */
 std::list<fake_listener::callback_info> const& fake_listener::get_callbacks()
     const throw() {
-  return (_callbacks);
+  return _callbacks;
 }
 
 /**
@@ -78,7 +44,6 @@ void fake_listener::on_eof() {
   callback_info ci;
   ci.callback = cb_eof;
   _callbacks.push_back(ci);
-  return;
 }
 
 /**
@@ -93,7 +58,6 @@ void fake_listener::on_error(uint64_t cmd_id, char const* msg) {
   callback_info ci;
   ci.callback = cb_error;
   _callbacks.push_back(ci);
-  return;
 }
 
 /**
@@ -112,7 +76,7 @@ void fake_listener::on_error(uint64_t cmd_id, char const* msg) {
  *  @param[in] is_ipv6     Work with IPv6.
  */
 void fake_listener::on_execute(uint64_t cmd_id,
-                               time_t timeout,
+                               const timestamp& timeout,
                                std::string const& host,
                                unsigned short port,
                                std::string const& user,
@@ -136,7 +100,6 @@ void fake_listener::on_execute(uint64_t cmd_id,
   ci.skip_stderr = skip_stderr;
   ci.is_ipv6 = is_ipv6;
   _callbacks.push_back(ci);
-  return;
 }
 
 /**
@@ -146,7 +109,6 @@ void fake_listener::on_quit() {
   callback_info ci;
   ci.callback = cb_quit;
   _callbacks.push_back(ci);
-  return;
 }
 
 /**
@@ -156,7 +118,6 @@ void fake_listener::on_version() {
   callback_info ci;
   ci.callback = cb_version;
   _callbacks.push_back(ci);
-  return;
 }
 
 /**************************************
@@ -172,7 +133,6 @@ void fake_listener::on_version() {
  */
 void fake_listener::_copy(fake_listener const& fl) {
   _callbacks = fl._callbacks;
-  return;
 }
 
 /**************************************
@@ -204,7 +164,8 @@ bool operator==(std::list<fake_listener::callback_info> const& left,
       if ((it1->callback != it2->callback) ||
           ((it1->callback == fake_listener::cb_execute) &&
            ((it1->cmd_id != it2->cmd_id) ||
-            (fabs(it1->timeout - it2->timeout) >= 1.0) ||
+            (fabs(it1->timeout.to_seconds() - it2->timeout.to_seconds()) >=
+             1.0) ||
             (it1->host != it2->host) || (it1->port != it2->port) ||
             (it1->user != it2->user) || (it1->password != it2->password) ||
             (it1->identity != it2->identity) ||
@@ -213,7 +174,7 @@ bool operator==(std::list<fake_listener::callback_info> const& left,
             (it1->is_ipv6 != it2->is_ipv6) || (it1->cmds != it2->cmds))))
         retval = false;
   }
-  return (retval);
+  return retval;
 }
 
 /**
@@ -226,5 +187,5 @@ bool operator==(std::list<fake_listener::callback_info> const& left,
  */
 bool operator!=(std::list<fake_listener::callback_info> const& left,
                 std::list<fake_listener::callback_info> const& right) {
-  return (!operator==(left, right));
+  return !operator==(left, right);
 }

--- a/ssh/test/orders/fake_listener.hh
+++ b/ssh/test/orders/fake_listener.hh
@@ -21,6 +21,9 @@
 
 #include <list>
 #include "com/centreon/connector/ssh/orders/listener.hh"
+#include "com/centreon/timestamp.hh"
+
+using namespace com::centreon;
 
 /**
  *  @class fake_listener fake_listener.hh "test/orders/fake_listener.hh"
@@ -40,7 +43,7 @@ class fake_listener : public com::centreon::connector::ssh::orders::listener {
   struct callback_info {
     e_callback callback;
     uint64_t cmd_id;
-    time_t timeout;
+    timestamp timeout;
     std::string host;
     unsigned short port;
     std::string user;
@@ -60,7 +63,7 @@ class fake_listener : public com::centreon::connector::ssh::orders::listener {
   void on_eof();
   void on_error(uint64_t cmd_id, char const* msg);
   void on_execute(uint64_t cmd_id,
-                  time_t timeout,
+                  const timestamp& timeout,
                   std::string const& host,
                   unsigned short port,
                   std::string const& user,

--- a/ssh/test/orders/parser/execute.cc
+++ b/ssh/test/orders/parser/execute.cc
@@ -67,15 +67,16 @@ int main() {
     retval = 1;
   else {
     fake_listener::callback_info info1, info2;
-    time_t comparison_timeout(time(NULL) + 4242);
+    timestamp comparison_timeout(timestamp::now() + 4242);
     info1 = *listnr.get_callbacks().begin();
     info2 = *++listnr.get_callbacks().begin();
     std::cout << "order ID:   " << fake_listener::cb_execute << std::endl
               << "            " << info1.callback << std::endl
               << "command ID: " << 1478523697531598258ull << std::endl
               << "            " << info1.cmd_id << std::endl
-              << "timeout:    " << comparison_timeout << std::endl
-              << "            " << info1.timeout << std::endl << "host:       "
+              << "timeout:    " << comparison_timeout.to_seconds() << std::endl
+              << "            " << info1.timeout.to_seconds() << std::endl
+              << "host:       "
               << "localhost" << std::endl << "            " << info1.host
               << std::endl << "user:       "
               << "root" << std::endl << "            " << info1.user
@@ -86,7 +87,8 @@ int main() {
               << "            " << info1.cmds.front() << std::endl;
     retval |= ((info1.callback != fake_listener::cb_execute) ||
                (info1.cmd_id != 1478523697531598258ull) ||
-               ((comparison_timeout - info1.timeout) > 1) ||
+               ((comparison_timeout.to_mseconds() -
+                 info1.timeout.to_mseconds()) > 1) ||
                (info1.host != "localhost") || (info1.user != "root") ||
                (info1.password != "myverysecretpassword") ||
                (info1.cmds.size() != 1) ||


### PR DESCRIPTION
Same patch as MON-4969-timeout but based on the master branch.